### PR TITLE
Add CI to push to ghrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  merge_group: {}
+  pull_request: {}
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Use build-and-push-to-ghcr action
+        uses: lsst-sqre/build-and-push-to-ghcr@v1
+        id: build
+        with:
+          image: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile: Dockerfile
+          context: .
+
+      - name: Output image name
+        run: echo "Pushed ghcr.io/${{ github.repository }}:${{ steps.build.outputs.tag }}"
+
+  check-ref:
+    runs-on: ubuntu-latest
+
+    if: >
+      !startsWith(github.ref, 'refs/tags/')
+      && !startsWith(github.head_ref, 'tickets/')
+
+    steps:
+      - name: Print branch message
+        run: echo "No workflow executed since  github.ref != 'refs/tags/' or github.head_ref != 'tickets/'"


### PR DESCRIPTION
Add some CI to get the tags for the deployment. All new developments need to fit with `github.ref or github.head_ref`